### PR TITLE
Pass old row data when modifying rows

### DIFF
--- a/src/dtable.js
+++ b/src/dtable.js
@@ -287,7 +287,7 @@ class DTable {
     if (JSON.stringify(oldData) === JSON.stringify(newUpdated)) {
       return;
     }
-    this.dtableStore.modifyRow(tableIndex, row._id, newUpdated, null);
+    this.dtableStore.modifyRow(tableIndex, row._id, newUpdated, oldData);
   }
 
   forEachRow(tableName, viewName, callback, { convertLinkID } = {}) {


### PR DESCRIPTION
## Summary
- Preserve and pass the previous row data to `modifyRow` when updating a row.
- Enable downstream logic to compare or process row changes with the original values.

## Testing
- Not run (not requested)